### PR TITLE
Fix failing tests due to changes in JSON format

### DIFF
--- a/test/unit/test_loadmodule.py
+++ b/test/unit/test_loadmodule.py
@@ -536,7 +536,7 @@ class ValkeyAuditLoadmoduleTest(unittest.TestCase):
             try:
                 json_entry = json.loads(line)
                 if "command" in json_entry and json_entry["command"] == "SET":
-                    self.assertIn("key=", json_entry["details"])
+                    self.assertIn("key=", json_entry["command_args"])
                     valid_json_found = True
             except json.JSONDecodeError:
                 print(f"Invalid JSON in line: {line}")
@@ -726,9 +726,9 @@ class ValkeyAuditLoadmoduleTest(unittest.TestCase):
                 json_entry = json.loads(line)
                 if json_entry.get("command") == "SET":
                     set_cmd_found = True
-                    self.assertIn("key1", json_entry["details"])
+                    self.assertIn("key1", json_entry["command_args"])
                     # Check that value is truncated (if it's included)
-                    details = json_entry["details"]
+                    details = json_entry["command_args"]
                     if "payload" in details:
                         self.assertIn(max_value, details)
                         parts = details.split("payload=")


### PR DESCRIPTION
#31 changed the JSON format to:
```json
{
        "timestamp": "%s",
        "category": "%s",
        "command": "%s",
        "command_args": "%s",
        "result": "%s",
        "duration_us": 1111,
        "keys_modified": 1111,
        "client_id": 1111,
        "username": "%s",
        "client_ip": "%s",
        "client_port": 1111,
        "server_hostname": "%s",
        "error": "%s"
}
```

But the tests are still getting fields based on the old format
```python
                if json_entry.get("command") == "SET":
                    set_cmd_found = True
                    self.assertIn("key1", json_entry["details"])
```
